### PR TITLE
Fix testJava8 task incompability

### DIFF
--- a/extra/interface/ap/build.gradle
+++ b/extra/interface/ap/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 // there is no javadoc
 tasks.withType(Javadoc).configureEach { enabled = false }
 
-tasks.withType(Test).configureEach {
+tasks.withType(Test).matching { it.name != "testJava8" }.configureEach {
     // See: https://github.com/google/compile-testing/issues/222
     jvmArgs '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
     jvmArgs '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED'


### PR DESCRIPTION
# Description
This PR specifically ignores the 'testJava8' task using `.matching`, because Java 8 doesn't support the specified JVM arguments.

# How Was This Tested?
I simulated this using the `-PstrictMultireleaseVersions=true` Gradle property by defining it in `gradle.properties`.

# The Build Still Fails
The build still fails due to `java.lang.NoClassDefFoundError: com/sun/source/util/TreeScanner`. To fix this, we need to add `tools.jar` as a `testImplementation` dependency. We cannot access `tools.jar` using `org.gradle.internal.jvm.Jvm.current().getToolsJar()` because `org.gradle.internal.jvm.Jvm.current()` returns Java 11 .

There are two ways to define `tools.jar`:
1. Simply upload the `tools.jar` file into the `libs` folder and then use `testImplementation files("libs/tools.jar")`.
2. Upload `tools.jar` to a repository and then use it as a dependency.

I believe the second way is a cleaner approach.